### PR TITLE
Add support for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
-language: generic
-sudo: required
-dist: trusty
-env:
-- SWIFT_BRANCH=swift-4.0-branch SWIFT_VERSION=swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-02-a
-install:
-- mkdir swift
-- curl https://swift.org/builds/$SWIFT_BRANCH/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz -s | tar xz -C swift &> /dev/null
-script:
-- env PATH=$(pwd)/swift/$SWIFT_VERSION-ubuntu14.04/usr/bin:$PATH swift test -c release
+matrix:
+  include:
+  - os: osx
+    language: objective-c
+    osx_image: xcode9.0
+    script:
+      - swift test -c release
+  - os: linux
+    language: generic
+    sudo: required
+    dist: trusty
+    env:
+    - SWIFT_BRANCH=swift-4.0-branch SWIFT_VERSION=swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-02-a
+    install:
+    - mkdir swift
+    - curl https://swift.org/builds/$SWIFT_BRANCH/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz -s | tar xz -C swift &> /dev/null
+    script:
+    - env PATH=$(pwd)/swift/$SWIFT_VERSION-ubuntu14.04/usr/bin:$PATH swift test -c release

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
   - os: osx
     language: objective-c
-    osx_image: xcode9.0
+    osx_image: xcode9
     script:
       - swift test -c release
   - os: linux

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ ZLib is a standard compression/decompression library that is installed by defaul
 
 > Does MaxPNG work on Mac OSX?
 
-I don’t know as I have never tried building it on OSX, but there’s no reason it shouldn’t unless Zlib and the C standard library aren’t present. `import Glibc` may need to be replaced with `import Darwin`.
+MaxPNG works great on macOS with the preinstalled zlib.
 
 > What is the progressive API good for?
 

--- a/sources/maxpng/maxpng.swift
+++ b/sources/maxpng/maxpng.swift
@@ -1,5 +1,10 @@
+#if os(macOS)
+import Darwin
+import zlib
+#elseif os(Linux)
 import Zlib
 import Glibc
+#endif
 
 let PNG_SIGNATURE:[UInt8] = [137, 80, 78, 71, 13, 10, 26, 10]
 

--- a/tests/maxpng/tests.swift
+++ b/tests/maxpng/tests.swift
@@ -1,4 +1,9 @@
+#if os(macOS)
+import Darwin
+#elseif os(Linux)
 import Glibc
+#endif
+
 import MaxPNG
 
 let bold = "\u{001B}[1m"


### PR DESCRIPTION
macOS ships with its own `Zlib` module called `zlib` (note the lowercase name compared to `Zlib`).

On macOS, import this module instead of the `Zlib` module, and import `Darwin` instead of `Glibc`.